### PR TITLE
Update IFRs.py

### DIFF
--- a/merced/policies/IFRs.py
+++ b/merced/policies/IFRs.py
@@ -68,7 +68,7 @@ class Requirement_Merced_R_below_Crocker_Huffman_Dam(WaterLPParameter):
 
         if wyt == 1:  # Wet Year
             if mth == 10:
-                if dy < 15:
+                if dy <= 15:
                     ferc_lic_flow = 0.71  # 25 cfs
                 else:
                     ferc_lic_flow = 2.12  # 75 cfs
@@ -80,7 +80,7 @@ class Requirement_Merced_R_below_Crocker_Huffman_Dam(WaterLPParameter):
                 ferc_lic_flow = 0.71  # 25 cfs
         else:  # Dry Year
             if mth == 10:
-                if dy < 15:
+                if dy <= 15:
                     ferc_lic_flow = 0.43  # 15 cfs
                 else:
                     ferc_lic_flow = 1.7  # 60 cfs


### PR DESCRIPTION
Double checked FERC License IFR section

1. Changed date threshold from < 15 to <=15.
2. Between November 1 - December 31, there is a Maximum Instream Flow of 150 cfs (for Dry years) or 200 cfs (non-Dry years) below Merced Falls Powerhouse.
3. The more precise location of this IFR is at Shaffer Bridge, but I think Aditya explained this is not a important difference.

4. Is there another IFR below Exchequer Dam of 25 cfs (constant)?  I couldn't find it.